### PR TITLE
Install: Handle tags and branchs for kern download

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -254,7 +254,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: ARM-Ubuntu24
+          - runner: ARM-Ubuntu24-blueos
             platform: "linux/arm64/v8"
             os: "bookworm"
             image: "raspios_lite_arm64/images/raspios_lite_arm64-2024-07-04/2024-07-04-raspios-bookworm-arm64-lite.img.xz"
@@ -339,7 +339,7 @@ jobs:
             echo "ASSET_NAME_SUFFIX=-pi4" >> $GITHUB_ENV
           elif [[ ${{ matrix.runner }} == 'pi-rasp12' ]]; then
             echo "ASSET_NAME_SUFFIX=-pi-rasp12" >> $GITHUB_ENV
-          elif [[ ${{ matrix.runner }} == 'ARM-Ubuntu24' ]]; then
+          elif [[ ${{ matrix.runner }} == 'ARM-Ubuntu24-blueos' ]]; then
             echo "ASSET_NAME_SUFFIX=-ci-ubu24-arm64" >> $GITHUB_ENV
           else
             echo "ASSET_NAME_SUFFIX=" >> $GITHUB_ENV

--- a/install/install.sh
+++ b/install/install.sh
@@ -290,7 +290,25 @@ if [ -z "$SKIP_KERNEL_INSTALL" ]; then
     KERNEL_DEB_FILENAME="linux-image-${KERNEL_VERSION}-${KERNEL_COMPILE_BASE}_${KERNEL_ARCH_SUFFIX}.deb"
 
     echo "Installing kernel version ${KERNEL_VERSION} with compile base ${KERNEL_COMPILE_BASE} and arch ${KERNEL_ARCH_SUFFIX}."
-    wget "https://github.com/MithalAS/BlueOS/raw/refs/heads/${VERSION}/${KERNEL_DEB_FILENAME}"
+
+    # Try to download the kernel package from a tag first, then from a branch (heads) as a fallback.
+    KERNEL_URL_TAGS="${REMOTE}/refs/tags/${VERSION}/${KERNEL_DEB_FILENAME}"
+    KERNEL_URL_HEADS="${REMOTE}/refs/heads/${VERSION}/${KERNEL_DEB_FILENAME}"
+
+    echo "Attempting to download kernel package (tags then heads)" >> "$STATUS_FILE"
+    if wget -q -O "${KERNEL_DEB_FILENAME}" "$KERNEL_URL_TAGS"; then
+        echo "Downloaded kernel package from tags: ${KERNEL_URL_TAGS}" >> "$STATUS_FILE"
+    elif wget -q -O "${KERNEL_DEB_FILENAME}" "$KERNEL_URL_HEADS"; then
+        echo "Downloaded kernel package from heads: ${KERNEL_URL_HEADS}" >> "$STATUS_FILE"
+    else
+        {
+            echo "Failed to download kernel package from both tags and heads:"
+            echo "  tried: ${KERNEL_URL_TAGS}"
+            echo "  tried: ${KERNEL_URL_HEADS}"
+            echo "Aborting kernel installation."
+        } >> "$STATUS_FILE"
+        exit 1
+    fi
 
     if sudo dpkg -i "${KERNEL_DEB_FILENAME}"; then
         echo "Kernel package installed successfully." >> "$STATUS_FILE"


### PR DESCRIPTION
Kernel install failed because when we use a git tag as a ref, the path is different, than we we use a branch.